### PR TITLE
Change recommended versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ If you are still getting the "SScript is not available, thanks to everyone for t
 | Psych Version | SScript |
 | -------- | ------- |
 | 1.0b (Pre [HScript-Iris](https://www.github.com/crowplexus/HScript-Iris/)) | from 17.0.618 to 21.0.0 |
-| 0.7.3    | 8.1.6 |
+| 0.7.3    | 7.7.0 |
 | 0.7.2    | 7.7.0 |
-| 0.7.1    | 7.7.0 |
+| 0.7.1h    | 4.0.1 |
+| 0.7.1    | from 3.0.0 to 4.0.1 |
 | [main](https://www.github.com/ShadowMario/FNF-PsychEngine/tree/main/) (as of Sep. 9, 2024) | 7.7.0 to 8.1.6 |
 
 ### For other projects

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are still getting the "SScript is not available, thanks to everyone for t
 | -------- | ------- |
 | 1.0b (Pre [HScript-Iris](https://www.github.com/crowplexus/HScript-Iris/)) | from 17.0.618 to 21.0.0 |
 | 0.7.3    | 7.7.0 |
-| 0.7.2    | 7.7.0 |
+| 0.7.2 to 0.7.2h    | 7.7.0 |
 | 0.7.1h    | 4.0.1 |
 | 0.7.1    | from 3.0.0 to 4.0.1 |
 | [main](https://www.github.com/ShadowMario/FNF-PsychEngine/tree/main/) (as of Sep. 9, 2024) | 7.7.0 to 8.1.6 |


### PR DESCRIPTION
0.7.1 presumably uses 3.0.0 but may be higher (doesnt really matter because hscript doesnt even work there lol)
0.7.1h uses 4.0.1, has `parsingExceptions` (not to be confused with `parsingException`, which is NOT an array) and of course, `SCall`.
0.7.2 and pretty sure 0.7.3 uses 7.7.0 (8.1.6 removed wildcard imports)
I didn't change 1.0 but Shadow Mario said 21 broke some stuff and that's why he downgraded to 19
I don't really care enough to know what broke so yea whatever